### PR TITLE
dockerize dynamic-fhir-servers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+Dockerfile.database
+docker-compose.yml
+db/seeds/package/*
+db/seeds/synthea/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM phusion/passenger-ruby27:1.0.12
+
+ENV RAILS_ENV development
+
+RUN mkdir /home/app/dfs
+
+WORKDIR /home/app/dfs
+
+ADD Gemfile /home/app/dfs/Gemfile
+ADD Gemfile.lock /home/app/dfs/Gemfile.lock
+
+RUN chown -R app:app .
+
+RUN su app -c "bundle config set without 'test'; bundle install"
+
+ADD . /home/app/dfs
+
+# This line is a duplicate however it is done to significantly speed up testing. With this line twice
+# we are able to do the bundle install earlier on which means it is cached more often.
+RUN chown -R app:app .
+RUN chmod -R 0755 .
+
+ENTRYPOINT ["./bin/rails", "server", "-b", "0.0.0.0"]
+
+EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM phusion/passenger-ruby27:1.0.12
 
+RUN apt-get update \
+  && apt-get upgrade -y -o Dpkg::Options::="--force-confold" \
+  && apt-get install -y postgresql-client \
+  && rm -rf /var/lib/apt/lists/*
+
 ENV RAILS_ENV development
 
 RUN mkdir /home/app/dfs
@@ -15,11 +20,16 @@ RUN su app -c "bundle config set without 'test'; bundle install"
 
 ADD . /home/app/dfs
 
+ADD config/database.docker.yml /home/app/dfs/config/database.yml
+ADD config/config.docker.json /home/app/dfs/config/config.json
+
 # This line is a duplicate however it is done to significantly speed up testing. With this line twice
 # we are able to do the bundle install earlier on which means it is cached more often.
 RUN chown -R app:app .
 RUN chmod -R 0755 .
 
-ENTRYPOINT ["./bin/rails", "server", "-b", "0.0.0.0"]
+ENTRYPOINT ["/home/app/dfs/bin/docker-entrypoint.sh"]
+
+CMD ["./bin/rails", "server", "-b", "0.0.0.0"]
 
 EXPOSE 3000

--- a/Dockerfile.database
+++ b/Dockerfile.database
@@ -1,0 +1,2 @@
+FROM postgres:12-alpine
+COPY db/structure.sql /docker-entrypoint-initdb.d/

--- a/README.md
+++ b/README.md
@@ -111,3 +111,11 @@ rails s
 ```
 
 #### Note: https://github.com/inferno-community/fhir-validator-wrapper must be running on port 4567 if using search commands
+
+## Running in Docker
+
+To run this service in Docker, run the following commands in the `dynamic-fhir-servers` directory:
+* `docker-compose up --build`
+* (once the prior command has started all the containers): `docker-compose run dfs bin/setup_db.sh`
+
+The docker-compose maps the `package` and `synthea` directories in `db/seeds` into the container. Re-running `docker-compose run dfs bin/setup_db.sh` after changing those directories (and restarting the `dfs` container by running `docker-compose restart dfs`) will re-seed the database with the new structure. To clear the old structure prior to reloading, run `docker-compose run dfs bin/rake db:drop`.

--- a/README.md
+++ b/README.md
@@ -118,4 +118,12 @@ To run this service in Docker, run the following commands in the `dynamic-fhir-s
 * `docker-compose up --build`
 * (once the prior command has started all the containers): `docker-compose run dfs bin/setup_db.sh`
 
+### Rails port configuration
+
+The docker-compose configuration maps the rails endpoint to port `3000` on the host machine.
+
+To change this, change the `ports` line in the `dfs` entry in `docker-compose.yml` from `- "3000:3000"` to `- "<your_desired_port>:3000"`, and restart the containers.
+
+For example: `- "8080:3000"` will map the rails endpoint to port `8080` on your machine.
+
 The docker-compose maps the `package` and `synthea` directories in `db/seeds` into the container. Re-running `docker-compose run dfs bin/setup_db.sh` after changing those directories (and restarting the `dfs` container by running `docker-compose restart dfs`) will re-seed the database with the new structure. To clear the old structure prior to reloading, run `docker-compose run dfs bin/rake db:drop`.

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -116,7 +116,7 @@ class SearchController < ApplicationController
           end
 
           # external integration to get result of FHIR expression
-          uri = URI("http://localhost:4567/evaluate?path=#{queryExpression}")
+          uri = URI("#{Rails.configuration.validatorURL}/evaluate?path=#{queryExpression}")
           req = Net::HTTP::Post.new(uri, 'Content-Type' => 'application/json')
           req.body = jsonResult.to_json
           res = Net::HTTP.start(uri.hostname, uri.port) do |http|

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# https://stackoverflow.com/a/38732187/1935918
+set -e
+
+if [ -f /app/tmp/pids/server.pid ]; then
+  rm /app/tmp/pids/server.pid
+fi
+
+exec bundle exec "$@"

--- a/bin/setup_db.sh
+++ b/bin/setup_db.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+bin/rake db:prepare
+bin/rake db:seed json_file='package'
+bin/rake db:seed json_file='synthea'

--- a/config/config.docker.json
+++ b/config/config.docker.json
@@ -1,4 +1,4 @@
 {
     "capabilityStatementName": "CapabilityStatement-us-core-server.json",
-    "validatorURL": "http://localhost:4567"
+    "validatorURL": "http://validator:4567"
 }

--- a/config/database.docker.yml
+++ b/config/database.docker.yml
@@ -1,0 +1,39 @@
+# PostgreSQL. Versions 9.1 and up are supported.
+#
+# Install the pg driver:
+#   gem install pg
+# On OS X with Homebrew:
+#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
+# On OS X with MacPorts:
+#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
+# On Windows:
+#   gem install pg
+#       Choose the win32 build.
+#       Install PostgreSQL and put its /bin directory on your path.
+#
+# Configure Using Gemfile
+# gem 'pg'
+#
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: postgres
+  password: dfspass1
+  host: db
+  timeout: 5000
+
+development:
+  <<: *default
+  database: cs6440_development
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  <<: *default
+  database: cs6440_test
+
+production:
+  <<: *default
+  database: cs6440_production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,33 @@ services:
     ports:
       - "3000:3000"
     restart: unless-stopped
+    depends_on:
+      - db
+      - validator
+    networks:
+      - dfsnet
+    environment:
+      - RAILS_LOG_TO_STDOUT=true
+    volumes:
+      - ./db/seeds:/home/app/dfs/db/seeds:ro
+  db:
+    image: postgres:12-alpine
+    volumes:
+      - dfs-pgdata:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
+      - PGPASSWORD=dfspass1
+    restart: unless-stopped
+    networks:
+      - dfsnet
+  validator:
+    image: infernocommunity/fhir-validator-service:latest
+    restart: unless-stopped
+    networks:
+      - dfsnet
+
+networks:
+  dfsnet:
+
+volumes:
+  dfs-pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3"
+
+services:
+  dfs:
+    build:
+      context: .
+    ports:
+      - "3000:3000"
+    restart: unless-stopped


### PR DESCRIPTION
Adds a docker toolchain for dynamic-fhir-servers, which allows for running dfs with docker-compose. 

To test, run:
* `docker-compose up --build`
* (once the prior command starts all the containers): `docker-compose run dfs bin/setup_db.sh`